### PR TITLE
Add instructions for installing libXcursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,28 @@ A rust based Ray tracer following the Ray Tracing in a weekend book.
 
 Runs with nightly rustc
 
-#build instructions
+# Build instructions
 
-1. install rustup/rust/cargo from https://rustup.rs/
-2. run rustup install nightly
-3. run rustup default nightly
-4. cd into directory that has the Cargo.toml file
-5. cargo run --release
-6. Enjoy
+## Dependencies
+
+Mars depends on `libXcursor`. Install it using your system's package manager.
+
+Ubuntu:
+
+```
+$ sudo apt install libXcursor-dev
+```
+
+Fedora:
+
+```
+$ sudo dnf install libXcursor-devel
+```
+
+## Building with Rust
+
+1. Install rustup/rust/cargo from https://rustup.rs/
+2. Run `rustup install nightly` (or `rustup update nightly`)
+3. Run `rustup override set nightly` while in the `mars/` directory
+4. Run `cargo run --release`
+5. Enjoy


### PR DESCRIPTION
When I went to run this I needed to install `libXcursor-devel` (Fedora), so I added that to the README.

Also I changed the build instructions to use `rustup override set nightly`, which will make it so that only the `mars/` project gets built with nightly, and cargo will use the default for everything else.